### PR TITLE
Integrate measurements crate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,13 +18,21 @@ jobs:
           name: Show versions
           command: rustc --version && cargo --version
 
-      # Build
+      # Default features
       - run:
-          name: Build
+          name: Build (default)
           command: cargo build
       - run:
-          name: Test
+          name: Test (default)
           command: cargo test
+
+      # Feature: measurements
+      - run:
+          name: Build (measurements)
+          command: cargo build --features measurements
+      - run:
+          name: Test (measurements)
+          command: cargo test --features measurements
 
       # Save cache
       - save_cache:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,17 @@ include = [
     "LICENSE-APACHE",
 ]
 
+[features]
+default = []
+
 [dependencies]
 byteorder = "1.2"
 embedded-hal = "0.1.0"
 bitflags = "1.0"
+
+[dependencies.measurements]
+version = "0.9"
+optional = true
 
 [dev-dependencies]
 linux-embedded-hal = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Details and datasheet: http://www.microchip.com/wwwproducts/en/en533561
 - [x] Docs
 
 
+## Feature Flags
+
+The following feature flags exists:
+
+- `measurements`: Use the
+  [measurements](https://github.com/thejpster/rust-measurements) crate
+  to represent voltages instead of the custom
+  [`Voltage`](https://docs.rs/mcp3425/*/mcp3425/struct.Voltage.html) wrapper
+
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
It's behind the `measurements` feature flag.

Only merge once a release of the `measurements`crate is out on crates.io!

Fixes #6. CC @thejpster.