### PR TITLE
Support MCP3426/7/8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ include = [
 
 [features]
 default = []
+# Support for MCP3426 and MCP3427
+dual_channel = []
+# Support for MCP3428
+quad_channel = []
 
 [dependencies]
 byteorder = "1.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io Version][crates-io-badge]][crates-io]
 [![Crates.io Downloads][crates-io-download-badge]][crates-io-download]
 
-This is a platform agnostic Rust driver for the MCP3425, based on the
+This is a platform agnostic Rust driver for the MCP3425/6/7/8, based on the
 [`embedded-hal`](https://github.com/japaric/embedded-hal) traits.
 
 Docs: https://docs.rs/mcp3425
@@ -20,6 +20,10 @@ The device has an I²C interface and an on-board ±2048mV reference.
 
 Details and datasheet: http://www.microchip.com/wwwproducts/en/en533561
 
+Variants [MCP3426/7/8](https://ww1.microchip.com/downloads/en/DeviceDoc/22226a.pdf) are supported as well, but require
+to enable one of the following features:
+* `dual_channel` for MCP3426/7
+* `quad_channel` for MCP3428
 
 ## Status
 
@@ -27,6 +31,7 @@ Details and datasheet: http://www.microchip.com/wwwproducts/en/en533561
 - [x] Support continuous measurements
 - [x] Configurable sample rate / resolution
 - [x] Configurable gain (PGA)
+- [x] Configurable channel (only MCP3426/7/8)
 - [x] Handle saturation values (high and low)
 - [x] Docs
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-# Rust MCP3425 Driver
+# Rust MCP3425/6/7/8 Driver
 
 [![GitHub Actions][github-actions-badge]][github-actions]
 [![Crates.io Version][crates-io-badge]][crates-io]
 [![Crates.io Downloads][crates-io-download-badge]][crates-io-download]
 
-This is a platform agnostic Rust driver for the MCP3425/6/7/8, based on the
-[`embedded-hal`](https://github.com/japaric/embedded-hal) traits.
+This is a platform agnostic Rust driver for the MCP3425 (and newer variants
+MCP3426/MCP3427/MCP3428 as well), based on the
+[`embedded-hal`](https://github.com/rust-embedded/embedded-hal) traits.
 
 Docs: https://docs.rs/mcp3425
 
@@ -18,12 +19,15 @@ The Microchip MCP3425 is a low-current 16-bit analog-to-digital converter.
 
 The device has an I²C interface and an on-board ±2048mV reference.
 
-Details and datasheet: http://www.microchip.com/wwwproducts/en/en533561
+Details and datasheet: https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/22072b.pdf
 
-Variants [MCP3426/7/8](https://ww1.microchip.com/downloads/en/DeviceDoc/22226a.pdf) are supported as well, but require
-to enable one of the following features:
-* `dual_channel` for MCP3426/7
-* `quad_channel` for MCP3428
+Variants [MCP3426/7/8](https://ww1.microchip.com/downloads/en/DeviceDoc/22226a.pdf)
+are very similar, but support multiple input channels. They are supported as
+well, but require to enable one of the following Cargo features:
+
+- `dual_channel` for MCP3426/7
+- `quad_channel` for MCP3428
+
 
 ## Status
 
@@ -34,16 +38,6 @@ to enable one of the following features:
 - [x] Configurable channel (only MCP3426/7/8)
 - [x] Handle saturation values (high and low)
 - [x] Docs
-
-
-## Feature Flags
-
-The following feature flags exists:
-
-- `measurements`: Use the
-  [measurements](https://github.com/thejpster/rust-measurements) crate
-  to represent voltages instead of the custom
-  [`Voltage`](https://docs.rs/mcp3425/*/mcp3425/struct.Voltage.html) wrapper
 
 
 ## License

--- a/examples/continuous.rs
+++ b/examples/continuous.rs
@@ -4,7 +4,7 @@ extern crate mcp3425;
 
 use hal::blocking::delay::DelayMs;
 use linux_hal::{Delay, I2cdev};
-use mcp3425::{Channel, Config, Gain, Resolution, MCP3425};
+use mcp3425::{Config, Gain, Resolution, MCP3425};
 
 fn main() {
     println!("Hello, MCP3425!");
@@ -24,7 +24,9 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let address = 0x68;
     let mut adc = MCP3425::continuous(dev, address, Delay);
-    let config = Config::new(Resolution::Bits16Sps15, Gain::Gain1, Channel::Channel1);
+    let config = Config::default()
+        .with_resolution(Resolution::Bits16Sps15)
+        .with_gain(Gain::Gain1);
 
     println!("Writing configuration to device: {:?}", &config);
     adc.set_config(&config).unwrap();

--- a/examples/continuous.rs
+++ b/examples/continuous.rs
@@ -4,7 +4,7 @@ extern crate mcp3425;
 
 use hal::blocking::delay::DelayMs;
 use linux_hal::{Delay, I2cdev};
-use mcp3425::{Config, Gain, Resolution, MCP3425};
+use mcp3425::{Channel, Config, Gain, Resolution, MCP3425};
 
 fn main() {
     println!("Hello, MCP3425!");
@@ -24,7 +24,7 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let address = 0x68;
     let mut adc = MCP3425::continuous(dev, address, Delay);
-    let config = Config::new(Resolution::Bits16Sps15, Gain::Gain1);
+    let config = Config::new(Resolution::Bits16Sps15, Gain::Gain1, Channel::Channel1);
 
     println!("Writing configuration to device: {:?}", &config);
     adc.set_config(&config).unwrap();

--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -2,7 +2,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate mcp3425;
 
 use linux_hal::{Delay, I2cdev};
-use mcp3425::{Channel, Config, Gain, Resolution, MCP3425};
+use mcp3425::{Config, Gain, Resolution, MCP3425};
 
 fn main() {
     println!("Hello, MCP3425!");
@@ -10,7 +10,7 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let address = 0x68;
     let mut adc = MCP3425::oneshot(dev, address, Delay);
-    let config = Config::new(Resolution::Bits12Sps240, Gain::Gain1, Channel::Channel1);
+    let config = Config::default();
 
     println!(
         "Temperature 12 bit / 1x gain: {:?}",

--- a/examples/oneshot.rs
+++ b/examples/oneshot.rs
@@ -2,7 +2,7 @@ extern crate linux_embedded_hal as linux_hal;
 extern crate mcp3425;
 
 use linux_hal::{Delay, I2cdev};
-use mcp3425::{Config, Gain, Resolution, MCP3425};
+use mcp3425::{Channel, Config, Gain, Resolution, MCP3425};
 
 fn main() {
     println!("Hello, MCP3425!");
@@ -10,7 +10,7 @@ fn main() {
     let dev = I2cdev::new("/dev/i2c-1").unwrap();
     let address = 0x68;
     let mut adc = MCP3425::oneshot(dev, address, Delay);
-    let config = Config::new(Resolution::Bits12Sps240, Gain::Gain1);
+    let config = Config::new(Resolution::Bits12Sps240, Gain::Gain1, Channel::Channel1);
 
     println!(
         "Temperature 12 bit / 1x gain: {:?}",


### PR DESCRIPTION
[MCP3426/7/8](https://ww1.microchip.com/downloads/en/DeviceDoc/22226a.pdf) have an almost identical interface, with the difference (please correct me if I'm wrong) that they have up to four input channels.
Therefore, it makes sense in my eyes to support these variants as well.

Does it make sense to add a feature flag to enable the channel configuration optionally?

I look forward to your feedback.

For a better overview of the changes, it makes sense to merge first #9.

